### PR TITLE
Add API permission and allow visitor by default

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -72,6 +72,9 @@ ram.runtime = "150M"
     login.url = "/auth/login"
     login.show_tile = false
     login.allowed = "all_users"
+    api.url = "/api"
+    api.show_tile = false
+    api.allowed = "visitors"
 
     [resources.ports]
     main.default = 8484


### PR DESCRIPTION
## Problem

- Users cannot use the Grist API if they don't allow the main permission to visitors

## Solution

- Introduce the API permission and set it to "visitors" by default

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
