### PR TITLE
Specify python3.11 for YunoHost 12

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -21,7 +21,7 @@ code = "https://github.com/gristlabs/grist-core/"
 fund = "https://github.com/sponsors/gristlabs"
 
 [integration]
-yunohost = ">= 11.2.30"
+yunohost = ">= 12"
 helpers_version = "2.1"
 architectures = "all"
 multi_instance = true
@@ -80,7 +80,7 @@ ram.runtime = "150M"
     main.default = 8484
 
     [resources.apt]
-    packages = "python3, python3-venv, redis-server"
+    packages = "python3.11, python3.11-venv, redis-server"
 
     extras.yarn.repo = "deb https://dl.yarnpkg.com/debian/ stable main"
     extras.yarn.key = "https://dl.yarnpkg.com/debian/pubkey.gpg"


### PR DESCRIPTION
Naïve attempt to fix https://forum.yunohost.org/t/grist-cannot-install-because-of-python3-dependency/32102, I am unsure that's the issue.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
