### PR TITLE
Logging out should disconnect from Yunohost too #64

### DIFF
--- a/conf/default.env
+++ b/conf/default.env
@@ -16,6 +16,7 @@ GRIST_SESSION_SECRET=__SESSION_SECRET__
 # Authentication
 GRIST_FORWARD_AUTH_HEADER=__EMAIL_HEADER__
 GRIST_IGNORE_SESSION=0 # SSOWat Removes the authentication headers: https://github.com/YunoHost/SSOwat/blob/38a6f23f3805a098b4ab757ff002f3a5fb3c377a/helpers.lua#L422-L425
+GRIST_FORWARD_AUTH_LOGOUT_PATH='/auth/ynh_logout'
 
 
 # Widget list URL

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -21,6 +21,10 @@ location / {
   include conf.d/yunohost_panel.conf.inc;
 }
 
+location /auth/ynh_logout {
+  return 301 $scheme://__MAIN_DOMAIN__/yunohost/sso?action=logout&r=__APP_HOME_URL_BASE64__;
+}
+
 location ~ .*/uploads$ {
   try_files /dev/null @api;
   client_max_body_size 10G;

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,6 +5,8 @@
 #=================================================
 
 nodejs_version=18
+main_domain=$(cat /etc/yunohost/current_host)
+app_home_url_base64=$(echo -n "https://$domain" | base64)
 
 get_email_header() {
   local yunohost_version=$(yunohost --version --json | jq -r ".yunohost.version")


### PR DESCRIPTION
## Problem

Fixes #64 

## Solution

Introduce a route `/auth/ynh_logout` that is handled by Nginx to redirect to the logout URI.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
